### PR TITLE
Fix offset in `dist`

### DIFF
--- a/network/dhtree.go
+++ b/network/dhtree.go
@@ -768,12 +768,12 @@ func (info *treeInfo) dist(dest *treeLabel) int {
 	if b < a {
 		a, b = b, a // make 'a' be the smaller value
 	}
-	lcaIdx := -1 // last common ancestor
+	lcaIdx := 0 // last common ancestor
 	for idx := 0; idx < a; idx++ {
 		if info.hops[idx].port != dest.path[idx] {
 			break
 		}
-		lcaIdx = idx
+		lcaIdx++
 	}
 	return a + b - 2*lcaIdx
 }

--- a/network/dhtree.go
+++ b/network/dhtree.go
@@ -768,14 +768,14 @@ func (info *treeInfo) dist(dest *treeLabel) int {
 	if b < a {
 		a, b = b, a // make 'a' be the smaller value
 	}
-	lcaIdx := 0 // last common ancestor
+	lcaIdx := -1 // last common ancestor
 	for idx := 0; idx < a; idx++ {
 		if info.hops[idx].port != dest.path[idx] {
 			break
 		}
-		lcaIdx++
+		lcaIdx = idx
 	}
-	return a + b - 2*lcaIdx
+	return a + b - 2*(lcaIdx+1)
 }
 
 func (info *treeInfo) encode(out []byte) ([]byte, error) {


### PR DESCRIPTION
Not that the offset particularly matters, but this way it’s easier to explain as it will actually match the number of hops when walking the tree.