### PR TITLE
Replace source routing with greedy routing

### DIFF
--- a/network/dhtree.go
+++ b/network/dhtree.go
@@ -264,6 +264,22 @@ func (t *dhtree) _treeLookup(dest *treeLabel) *peer {
 	return bestPeer
 }
 
+func (t *dhtree) handlePathTraffic(from phony.Actor, tr *pathTraffic) {
+	t.Act(from, func() {
+		//var label treeLabel // TODO lookups without a full label
+		//label.root = t.self.root
+		//label.seq = t.self.seq
+		label := *t._getLabel()
+		label.key = tr.dt.dest
+		label.path = tr.path
+		if next := t._treeLookup(&label); next != nil {
+			next.sendPathTraffic(t, tr)
+		} else {
+			t.handleDHTTraffic(nil, &tr.dt, false)
+		}
+	})
+}
+
 // _dhtLookup selects the next hop needed to route closer to the destination in dht keyspace
 // this only uses the source direction of paths through the dht
 // bootstraps use slightly different logic, since they need to stop short of the destination key
@@ -651,7 +667,8 @@ func (t *dhtree) sendTraffic(from phony.Actor, tr *dhtTraffic) {
 			pt := new(pathTraffic)
 			pt.path = path
 			pt.dt = *tr
-			t.core.peers.handlePathTraffic(t, pt)
+			//t.core.peers.handlePathTraffic(t, pt)
+			t.handlePathTraffic(nil, pt)
 		} else {
 			t.handleDHTTraffic(nil, tr, false)
 		}

--- a/network/dhtree.go
+++ b/network/dhtree.go
@@ -667,7 +667,6 @@ func (t *dhtree) sendTraffic(from phony.Actor, tr *dhtTraffic) {
 			pt := new(pathTraffic)
 			pt.path = path
 			pt.dt = *tr
-			//t.core.peers.handlePathTraffic(t, pt)
 			t.handlePathTraffic(nil, pt)
 		} else {
 			t.handleDHTTraffic(nil, tr, false)

--- a/network/pathfinder.go
+++ b/network/pathfinder.go
@@ -102,8 +102,12 @@ func (pf *pathfinder) handleNotify(from phony.Actor, n *pathNotify) {
 	pf.dhtree.Act(from, func() {
 		if next := pf.dhtree._dhtLookup(n.dest, false); next != nil {
 			next.sendPathNotify(pf.dhtree, n)
-		} else if l := pf._getLookup(n); l != nil {
-			pf.handleLookup(nil, l) // TODO pf._handleLookup
+			//} else if l := pf._getLookup(n); l != nil {
+			//	pf.handleLookup(nil, l) // TODO pf._handleLookup
+			//}
+		} else if info, isIn := pf.paths[n.label.key]; isIn {
+			info.path = append(info.path[:0], n.label.path...)
+			info.path = append(info.path, 0)
 		}
 	})
 }

--- a/network/peers.go
+++ b/network/peers.go
@@ -375,7 +375,7 @@ func (p *peer) _handlePathTraffic(bs []byte) error {
 		return err
 	}
 	// TODO? don't send to p.peers, have a (read-only) copy of the map locally? via atomics?
-	p.peers.handlePathTraffic(p, tr)
+	p.peers.core.dhtree.handlePathTraffic(p, tr)
 	return nil
 }
 


### PR DESCRIPTION
This set of changes is kind of an ugly hack and needs further testing, but I think the basic idea is sound.

This is mostly meant to address https://github.com/yggdrasil-network/yggdrasil-go/issues/851 by removing source routing and replacing it with the old style (ygg v0.3.X and earlier) greedy geographic routing. Since greedy routing is used for source route discovery, it results in the exact same paths being used in honest networks, but prevents the traffic amplification issues, at the cost of higher per-packet CPU use. If this is the route we decide to go, then the CPU use can be addressed in a later patch (there are data structures that would make the lookups much faster, but they're kind of hard to implement/use/debug).

Prior to this patch, source route discovery worked the following way:
1. When receiving a DHT-routed packet, if we care about the source address, then send a notification message back to the source. This contains treespace information (root/seq/coords). This is routed through the DHT keyspace.
2. When receiving a notification, if we care about the destination node, then send a path lookup. This saves the per-hop routing info for the path back to the source node. This is routed through the greedy embedded treespace.
3. When receiving a path lookup, reply with a path response. This saves the per-hop routing info back to the destination, which the source can use to send subsequent traffic. This is source routed (using the reverse route saved in the lookup).

With this patch, we instead immediately save the (signed) coords from the pathfinding notification message, and include those coords (instead of a source routing path) in `pathTraffic` messages. The other pathfinding message types are silently dropped (for now, later they will result in a disconnect with the peer).

This reuses the existing `pathTraffic` message type, but interprets the `path` field as a set of coords for greedy routing, instead of a source route. In a network with a mix of old and new nodes, some will try to use it for greedy routing, and some will try to source route. That will result in the packet being routed to some unrelated dead-end, where it falls back to DHT routing. This means a network that's in the process of being updated from the old version to the new version *should* continue to work, but certain node pairs may keep falling back to DHT routing (with slightly higher stretch) until the upgrade is complete.

Further testing is needed to make sure backwards compatibility is maintained and errors / obsolete packet types are all handled properly. There's also some room for additional small improvements and cleanup, e.g. it should be possible to simplify the notification throttling and keep-alive logic, since we don't need to periodically check for new source routes (we only need to send a notification when old coords can no longer route to us).