### PR TITLE
Priority tie-break between multiple peerings to the same node

### DIFF
--- a/network/core_test.go
+++ b/network/core_test.go
@@ -22,8 +22,8 @@ func TestTwoNodes(t *testing.T) {
 	cA, cB := newDummyConn(pubA, pubB)
 	defer cA.Close()
 	defer cB.Close()
-	go a.HandleConn(pubB, cA)
-	go b.HandleConn(pubA, cB)
+	go a.HandleConn(pubB, cA, 0)
+	go b.HandleConn(pubA, cB, 0)
 	waitForRoot([]*PacketConn{a, b}, 10*time.Second)
 	timer := time.NewTimer(time.Second)
 	defer func() { timer.Stop() }()
@@ -121,12 +121,12 @@ func TestLineNetwork(t *testing.T) {
 		defer linkB.Close()
 		go func() {
 			<-wait
-			prev.HandleConn(keyB, linkA)
+			prev.HandleConn(keyB, linkA, 0)
 			//linkA.Close()
 		}()
 		go func() {
 			<-wait
-			here.HandleConn(keyA, linkB)
+			here.HandleConn(keyA, linkB, 0)
 			//linkB.Close()
 		}()
 	}
@@ -236,11 +236,11 @@ func TestRandomTreeNetwork(t *testing.T) {
 			defer linkB.Close()
 			go func() {
 				<-wait
-				conn.HandleConn(keyB, linkA)
+				conn.HandleConn(keyB, linkA, 0)
 			}()
 			go func() {
 				<-wait
-				p.HandleConn(keyA, linkB)
+				p.HandleConn(keyA, linkB, 0)
 			}()
 		}
 		conns = append(conns, conn)

--- a/network/debug.go
+++ b/network/debug.go
@@ -24,12 +24,13 @@ type DebugSelfInfo struct {
 }
 
 type DebugPeerInfo struct {
-	Key     ed25519.PublicKey
-	Root    ed25519.PublicKey
-	Coords  []uint64
-	Port    uint64
-	Updated time.Time
-	Conn    net.Conn
+	Key      ed25519.PublicKey
+	Root     ed25519.PublicKey
+	Coords   []uint64
+	Port     uint64
+	Updated  time.Time
+	Conn     net.Conn
+	Priority uint8
 }
 
 type DebugDHTInfo struct {
@@ -70,6 +71,7 @@ func (d *Debug) GetPeers() (infos []DebugPeerInfo) {
 			info.Port = uint64(p.port)
 			info.Updated = tinfo.time
 			info.Conn = p.conn
+			info.Priority = p.prio
 			infos = append(infos, info)
 		}
 	})

--- a/network/packetconn.go
+++ b/network/packetconn.go
@@ -148,7 +148,7 @@ func (pc *PacketConn) SetWriteDeadline(t time.Time) error {
 // This function blocks while the net.Conn is in use, and returns an error if any occurs.
 // This function returns (almost) immediately if PacketConn.Close() is called.
 // In all cases, the net.Conn is closed before returning.
-func (pc *PacketConn) HandleConn(key ed25519.PublicKey, conn net.Conn) error {
+func (pc *PacketConn) HandleConn(key ed25519.PublicKey, conn net.Conn, prio uint8) error {
 	defer conn.Close()
 	if len(key) != publicKeySize {
 		return errors.New("incorrect key length")
@@ -158,7 +158,7 @@ func (pc *PacketConn) HandleConn(key ed25519.PublicKey, conn net.Conn) error {
 	if pc.core.crypto.publicKey.equal(pk) {
 		return errors.New("attempted to connect to self")
 	}
-	p, err := pc.core.peers.addPeer(pk, conn)
+	p, err := pc.core.peers.addPeer(pk, conn, prio)
 	if err != nil {
 		return err
 	}

--- a/network/peers.go
+++ b/network/peers.go
@@ -28,7 +28,7 @@ func (ps *peers) init(c *core) {
 	ps.peers = make(map[peerPort]*peer)
 }
 
-func (ps *peers) addPeer(key publicKey, conn net.Conn) (*peer, error) {
+func (ps *peers) addPeer(key publicKey, conn net.Conn, prio uint8) (*peer, error) {
 	var p *peer
 	var err error
 	ps.core.pconn.closeMutex.Lock()
@@ -54,6 +54,7 @@ func (ps *peers) addPeer(key publicKey, conn net.Conn) (*peer, error) {
 		p.port = port
 		p.writer.peer = p
 		p.writer.timer = time.AfterFunc(0, func() {})
+		p.prio = prio
 		ps.peers[port] = p
 	})
 	return p, err
@@ -81,6 +82,7 @@ type peer struct {
 	queue       packetQueue
 	ready       bool // is the writer ready for traffic?
 	writer      peerWriter
+	prio        uint8 // lower is better, relative only to other peerings to the same peer
 }
 
 type peerWriter struct {

--- a/types/packetconn.go
+++ b/types/packetconn.go
@@ -11,7 +11,7 @@ type PacketConn interface {
 	// This function blocks while the net.Conn is in use, and returns an error if any occurs.
 	// This function returns (almost) immediately if PacketConn.Close() is called.
 	// In all cases, the net.Conn is closed before returning.
-	HandleConn(key ed25519.PublicKey, conn net.Conn) error
+	HandleConn(key ed25519.PublicKey, conn net.Conn, prio uint8) error
 
 	// SendOutOfBand sends some out-of-band data to a key.
 	// The data will be forwarded towards the destination key as far as possible, and then handled by the out-of-band handler of the terminal node.


### PR DESCRIPTION
This allows specifying a `prio` number (lower is better) which is used to prioritise certain links when multiple peerings to the same node exist. It does not prioritise peerings between different nodes in any way. If the multiple links do not have distinct priorities (i.e. they are all zero or otherwise equal) then this code has no side effects.

It works by tie-breaking the tree routing using the priority field after the other checks, so that if we come across another higher priority link to the same next-hop node, we'll use it instead. In theory this should influence the path setup packets in particular, pushing them over higher priority links, resulting in the paths themselves being set up over those higher priority links.

It also adds another loop into the DHT routing to check that a higher priority link for the next-hop key is available, so that bootstrap, bootstrap ACK etc packets will also be prioritised.

In theory we could allow users to specify their own priorities in the peering URI or at the multicast scope level or similar, or we could do so automatically in some cases by link type (multicast vs statically configured). It could also be used to specifically deprioritise slower link types in the future (Bluetooth, for example).

This specifically does not modify the parent selection because it is quite likely that doing so would result in more spanning tree traffic in cases where the priority link isn't the lowest latency path to the root. If that were the case, you'd switch parent on a new tree update to the lowest latency link, and then you'd do so *again* when the higher priority link receives the update afterwards. It isn't really clear that the parent relationship really matters if we influence the forwarding pattern anyway.