### PR TITLE
Fine-tuning

### DIFF
--- a/network/core_test.go
+++ b/network/core_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"testing"
@@ -30,6 +31,7 @@ func TestTwoNodes(t *testing.T) {
 	tA := &a.core.dhtree
 	tB := &b.core.dhtree
 	for {
+		break // FIXME DEBUG testing without a tree
 		select {
 		case <-timer.C:
 			panic("timeout")
@@ -95,6 +97,22 @@ func TestTwoNodes(t *testing.T) {
 	}()
 	select {
 	case <-timer.C:
+		phony.Block(tA, func() {
+			for p := range tA.peers {
+				fmt.Println("DEBUG1:", tA.core.crypto.publicKey, p.key)
+			}
+			for k := range tA.dinfos {
+				fmt.Println("DEBUG2:", tA.core.crypto.publicKey, k)
+			}
+		})
+		phony.Block(tB, func() {
+			for p := range tB.peers {
+				fmt.Println("DEBUG1:", tB.core.crypto.publicKey, p.key)
+			}
+			for k := range tB.dinfos {
+				fmt.Println("DEBUG2:", tB.core.crypto.publicKey, k)
+			}
+		})
 		panic("timeout")
 	case <-done:
 	}
@@ -345,6 +363,7 @@ func TestRandomTreeNetwork(t *testing.T) {
 // waitForRoot is a helper function that waits until all nodes are using the same root
 // that should usually mean the network has settled into a stable state, at least for static network tests
 func waitForRoot(conns []*PacketConn, timeout time.Duration) {
+	return // FIXME DEBUG testing without a tree
 	begin := time.Now()
 	for {
 		if time.Since(begin) > timeout {

--- a/network/core_test.go
+++ b/network/core_test.go
@@ -98,16 +98,16 @@ func TestTwoNodes(t *testing.T) {
 	select {
 	case <-timer.C:
 		phony.Block(tA, func() {
-			for p := range tA.peers {
-				fmt.Println("DEBUG1:", tA.core.crypto.publicKey, p.key)
+			for k := range tA.peers {
+				fmt.Println("DEBUG1:", tA.core.crypto.publicKey, k)
 			}
 			for k := range tA.dinfos {
 				fmt.Println("DEBUG2:", tA.core.crypto.publicKey, k)
 			}
 		})
 		phony.Block(tB, func() {
-			for p := range tB.peers {
-				fmt.Println("DEBUG1:", tB.core.crypto.publicKey, p.key)
+			for k := range tB.peers {
+				fmt.Println("DEBUG1:", tB.core.crypto.publicKey, k)
 			}
 			for k := range tB.dinfos {
 				fmt.Println("DEBUG2:", tB.core.crypto.publicKey, k)

--- a/network/debug.go
+++ b/network/debug.go
@@ -78,13 +78,7 @@ func (d *Debug) GetPeers() (infos []DebugPeerInfo) {
 
 func (d *Debug) GetDHT() (infos []DebugDHTInfo) {
 	phony.Block(&d.c.dhtree, func() {
-		for _, dinfos := range d.c.dhtree.dinfos {
-			var dinfo *dhtInfo
-			for _, dfo := range dinfos {
-				// TODO dump all dhtInfos, not just one random one per map key
-				dinfo = dfo
-				break
-			}
+		for _, dinfo := range d.c.dhtree.dinfos {
 			var info DebugDHTInfo
 			info.Key = append(info.Key, dinfo.key[:]...)
 			if dinfo.peer != nil {

--- a/network/dhtree.go
+++ b/network/dhtree.go
@@ -13,7 +13,8 @@ const (
 	treeANNOUNCE = treeTIMEOUT / 2
 	treeTHROTTLE = treeANNOUNCE / 2 // TODO use this to limit how fast seqs can update
 	dhtANNOUNCE  = 9 * time.Second
-	dhtTIMEOUT   = dhtANNOUNCE + time.Second
+	dhtTOLERANCE = time.Second // Must be appreciably greater than dhtWINDOW
+	dhtTIMEOUT   = dhtANNOUNCE + dhtTOLERANCE
 	dhtCLEANUP   = dhtTIMEOUT
 	dhtWINDOW    = 250 * time.Millisecond
 	dhtTIMESTEP  = dhtWINDOW

--- a/network/dhtree.go
+++ b/network/dhtree.go
@@ -396,7 +396,6 @@ func (t *dhtree) _addBootstrapPath(bootstrap *dhtBootstrap, prev *peer) *dhtInfo
 		// We failed to add the dinfo to the DHT for some reason
 		return nil
 	}
-
 	return dinfo
 }
 
@@ -438,9 +437,11 @@ func (t *dhtree) _handleBootstrap(prev *peer, bootstrap *dhtBootstrap) {
 		bhs := bootstrap.bhs
 		bootstrap.bhs = bootstrap.bhs[:0]
 		for _, s := range bhs {
-			if dfo, isIn := t.dinfos[s.key]; isIn {
-				// This node has already seen it, so make sure we don't send it to them
-				delete(sendTo, dfo.peer)
+			// TODO something faster than this inner loop
+			for p := range t.peers {
+				if p.key.equal(s.key) {
+					delete(sendTo, p)
+				}
 			}
 			if dinfo.peer == nil || dinfo.peer.key != s.key {
 				continue

--- a/network/dhtree.go
+++ b/network/dhtree.go
@@ -12,9 +12,9 @@ const (
 	treeTIMEOUT  = time.Hour // TODO figure out what makes sense
 	treeANNOUNCE = treeTIMEOUT / 2
 	treeTHROTTLE = treeANNOUNCE / 2 // TODO use this to limit how fast seqs can update
-	dhtANNOUNCE  = 5 * time.Second
+	dhtANNOUNCE  = 9 * time.Second
 	dhtTIMEOUT   = dhtANNOUNCE + time.Second
-	dhtCLEANUP   = 2 * dhtTIMEOUT
+	dhtCLEANUP   = dhtTIMEOUT
 	dhtWINDOW    = 250 * time.Millisecond
 	dhtTIMESTEP  = dhtWINDOW
 )

--- a/network/pathfinder.go
+++ b/network/pathfinder.go
@@ -93,8 +93,8 @@ func (pf *pathfinder) _getPath(dest publicKey) []peerPort {
 
 func (pf *pathfinder) handleNotify(from phony.Actor, n *pathNotify) {
 	pf.dhtree.Act(from, func() {
-		if next := pf.dhtree._dhtLookup(n.dest, false, &n.mark); next != nil && next.peer != nil {
-			next.peer.sendPathNotify(pf.dhtree, n)
+		if next := pf.dhtree._dhtLookup(n.dest, false, &n.mark); next != nil {
+			next.sendPathNotify(pf.dhtree, n)
 			return
 		}
 		if !n.dest.equal(pf.dhtree.core.crypto.publicKey) {

--- a/network/pathfinder.go
+++ b/network/pathfinder.go
@@ -93,8 +93,8 @@ func (pf *pathfinder) _getPath(dest publicKey) []peerPort {
 
 func (pf *pathfinder) handleNotify(from phony.Actor, n *pathNotify) {
 	pf.dhtree.Act(from, func() {
-		if next := pf.dhtree._dhtLookup(n.dest, false, &n.mark); next != nil {
-			next.sendPathNotify(pf.dhtree, n)
+		if next := pf.dhtree._dhtLookup(n.dest, false, &n.mark); next != nil && next.peer != nil {
+			next.peer.sendPathNotify(pf.dhtree, n)
 			return
 		}
 		if !n.dest.equal(pf.dhtree.core.crypto.publicKey) {

--- a/network/peers.go
+++ b/network/peers.go
@@ -14,8 +14,8 @@ import (
 const (
 	peerENABLE_DELAY_SCALING = 0
 	peerRETRY_WINDOW         = 2 // seconds to wait between expected time and timeout
-	peerINIT_DELAY           = 4 // backwards compatibiity / historical reasons
-	peerINIT_TIMEOUT         = 6 // backwards compatiblity / historical reasons
+	peerINIT_DELAY           = 40 // backwards compatibiity / historical reasons
+	peerINIT_TIMEOUT         = 60 // backwards compatiblity / historical reasons
 	peerMIN_DELAY            = 1
 	peerMAX_DELAY            = 30 // TODO figure out what makes sense
 )
@@ -137,7 +137,7 @@ func (p *peer) handler() error {
 	defer func() {
 		p.peers.core.dhtree.remove(nil, p)
 	}()
-	p.peers.core.dhtree.addPeer(nil, p)
+	p.peers.core.dhtree.updatePeer(nil, p)
 	done := make(chan struct{})
 	defer close(done)
 	p.writer.keepAlive = func() {
@@ -186,6 +186,7 @@ func (p *peer) handler() error {
 		}
 		var err error
 		phony.Block(p, func() {
+			p.peers.core.dhtree.updatePeer(p, p)
 			err = p._handlePacket(bs)
 		})
 		if err != nil {

--- a/network/peers.go
+++ b/network/peers.go
@@ -304,34 +304,6 @@ func (p *peer) _handlePathTraffic(bs []byte) error {
 	return nil
 }
 
-/*
-func (p *peer) _handlePathTraffic(bs []byte) error {
-	tr := new(pathTraffic)
-	if err := tr.decode(bs); err != nil {
-		return err
-	}
-	// TODO? don't send to p.peers, have a (read-only) copy of the map locally? via atomics?
-	p.peers.handlePathTraffic(p, tr)
-	return nil
-}
-
-func (ps *peers) handlePathTraffic(from phony.Actor, tr *pathTraffic) {
-	ps.Act(from, func() {
-		var nextPort peerPort
-		if len(tr.path) > 0 {
-			nextPort, tr.path = tr.path[0], tr.path[1:]
-		}
-		if next := ps.peers[nextPort]; next != nil {
-			// Forward using the source routed path
-			next.sendPathTraffic(nil, tr)
-		} else {
-			// Fall back to dhtTraffic
-			ps.core.dhtree.handleDHTTraffic(ps, &tr.dt, false)
-		}
-	})
-}
-*/
-
 func (p *peer) sendPathTraffic(from phony.Actor, tr *pathTraffic) {
 	p.Act(from, func() {
 		p._push(tr)

--- a/network/peers.go
+++ b/network/peers.go
@@ -335,6 +335,7 @@ func (ps *peers) handlePathTraffic(from phony.Actor, tr *pathTraffic) {
 */
 
 func (p *peer) sendPathTraffic(from phony.Actor, tr *pathTraffic) {
+	return // DEBUG disable pathfinder
 	p.Act(from, func() {
 		p._push(tr)
 	})

--- a/network/peers.go
+++ b/network/peers.go
@@ -14,8 +14,8 @@ import (
 const (
 	peerENABLE_DELAY_SCALING = 0
 	peerRETRY_WINDOW         = 2 // seconds to wait between expected time and timeout
-	peerINIT_DELAY           = 3 // backwards compatibiity / historical reasons
-	peerINIT_TIMEOUT         = 5 // backwards compatiblity / historical reasons
+	peerINIT_DELAY           = 4 // backwards compatibiity / historical reasons
+	peerINIT_TIMEOUT         = 6 // backwards compatiblity / historical reasons
 	peerMIN_DELAY            = 1
 	peerMAX_DELAY            = 30 // TODO figure out what makes sense
 )
@@ -277,7 +277,6 @@ func (p *peer) _handlePathNotify(bs []byte) error {
 }
 
 func (p *peer) sendPathNotify(from phony.Actor, notify *pathNotify) {
-	return // FIXME DEBUG remove this, it's just to disable the pathfinder
 	p.Act(from, func() {
 		p.writer.sendPacket(wireProtoPathNotify, notify)
 	})

--- a/network/peers.go
+++ b/network/peers.go
@@ -14,8 +14,8 @@ import (
 const (
 	peerENABLE_DELAY_SCALING = 0
 	peerRETRY_WINDOW         = 2 // seconds to wait between expected time and timeout
-	peerINIT_DELAY           = 4 // backwards compatibiity / historical reasons
-	peerINIT_TIMEOUT         = 6 // backwards compatiblity / historical reasons
+	peerINIT_DELAY           = 3 // backwards compatibiity / historical reasons
+	peerINIT_TIMEOUT         = 5 // backwards compatiblity / historical reasons
 	peerMIN_DELAY            = 1
 	peerMAX_DELAY            = 30 // TODO figure out what makes sense
 )
@@ -277,6 +277,7 @@ func (p *peer) _handlePathNotify(bs []byte) error {
 }
 
 func (p *peer) sendPathNotify(from phony.Actor, notify *pathNotify) {
+	return // FIXME DEBUG remove this, it's just to disable the pathfinder
 	p.Act(from, func() {
 		p.writer.sendPacket(wireProtoPathNotify, notify)
 	})


### PR DESCRIPTION
WIP updates to go in the experimental branch / targeting ygg v0.5.

So getting here involves a bit of a detour. Basically, the soft state DHT was rewritten to not use the tree at all (the "root" is just broadcast B.A.T.M.A.N. style, and everything else is unicast), and then things were switched back to the tree. That uncovered some bugs/issues that the old code / dependence on the tree was originally hiding. The way the tree is used (at least in the DHT) is much simpler now: if `_dhtLookup` doesn't find a `dhtInfo` for a given address, then just forward to our parent. That ensures the root is reachable via `_dhtLookup` in exactly the cases where it's needed, which kicks off the usual proof-by-induction that the DHT converges.

Aside from that, some work has gone into making protocol traffic more adaptive in how it sends keepalives. The per-peer adaptive keepalive was switched on (with the timing/schedule adjusted), and dht bootstrap timings were made adaptive to help speed up convergence / improve mobility performance (and decrease idle bandwidth consumption in stable networks -- they throttle back to sending once every 5 seconds rather than once ever 3).

I want to sit this in a branch to keep testing for a bit, before I merge it into experimental. There's still work to be done on other things after that (queue stuff, possibly some `encrypted` stuff).