### PR TITLE
allows consumer to create customised types.Addr compatible types

### DIFF
--- a/encrypted/packetconn.go
+++ b/encrypted/packetconn.go
@@ -57,7 +57,7 @@ func (pc *PacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 		return 0, errors.New("closed")
 	default:
 	}
-	destKey, ok := addr.(types.Addr)
+	destKey, ok := types.ExtractAddrKey(addr)
 	if !ok || len(destKey) != edPubSize {
 		return 0, errors.New("bad destination address")
 	}

--- a/network/packetconn.go
+++ b/network/packetconn.go
@@ -71,10 +71,10 @@ func (pc *PacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 		return 0, errors.New("closed")
 	default:
 	}
-	if _, ok := addr.(types.Addr); !ok {
+	dest, ok := types.ExtractAddrKey(addr)
+	if !ok {
 		return 0, errors.New("incorrect address type, expected types.Addr")
 	}
-	dest := addr.(types.Addr)
 	if len(dest) != publicKeySize {
 		return 0, errors.New("incorrect address length")
 	}

--- a/types/addr.go
+++ b/types/addr.go
@@ -3,7 +3,27 @@ package types
 import (
 	"crypto/ed25519"
 	"encoding/hex"
+	"net"
 )
+
+// ConvertibleAddr is for apps that want to implement a custom address behaviour
+// but want to tell ironwood which public key to contact.
+type ConvertibleAddr interface {
+	IronwoodAddr() Addr
+}
+
+func ExtractAddrKey(a net.Addr) (addr Addr, ok bool) {
+	var destKey Addr
+	switch v := a.(type) {
+	case Addr:
+		destKey = v
+	case ConvertibleAddr:
+		destKey = v.IronwoodAddr()
+	default:
+		return nil, false
+	}
+	return destKey, true
+}
 
 // Addr implements the `net.Addr` interface for `ed25519.PublicKey` values.
 type Addr ed25519.PublicKey


### PR DESCRIPTION
This is needed to make https://github.com/Jorropo/go-pin-argente work.

I have to return a precise `[<ip>]:1` format in my `addr.String` method (that because `quic-go` REALLY wants to do SNI and I cannot just give it the public key I want to use). (don't look at the `:1` too much, it's just to make the SNI IP parser happy, I told it all connections happen on port 1 even tho no such thing exists)

However making my custom address type broke ironwood, this patch allows my custom address type to convert itself into ironwood friendly form.