### PR TITLE
Session uptime and RX/TX bytes tracking

### DIFF
--- a/encrypted/debug.go
+++ b/encrypted/debug.go
@@ -2,6 +2,7 @@ package encrypted
 
 import (
 	"crypto/ed25519"
+	"time"
 
 	"github.com/Arceliar/phony"
 )
@@ -15,14 +16,19 @@ func (d *Debug) init(pc *PacketConn) {
 }
 
 type DebugSessionInfo struct {
-	Key ed25519.PublicKey
+	Key    ed25519.PublicKey
+	Uptime time.Duration
+	RX     uint64
+	TX     uint64
 }
 
 func (d *Debug) GetSessions() (infos []DebugSessionInfo) {
 	phony.Block(&d.pc.sessions, func() {
-		for key := range d.pc.sessions.sessions {
+		for key, session := range d.pc.sessions.sessions {
 			var info DebugSessionInfo
 			info.Key = append(info.Key, key[:]...)
+			info.Uptime = time.Since(session.since)
+			info.RX, info.TX = session.rx, session.tx
 			infos = append(infos, info)
 		}
 	})


### PR DESCRIPTION
Somewhere along the lines we lost the ability to do this.