### PR TITLE
Reduce re-allocations in packet queues

### DIFF
--- a/network/packetqueue.go
+++ b/network/packetqueue.go
@@ -43,7 +43,8 @@ func (q *packetQueue) drop() bool {
 	stream := q.streams[longestIdx]
 	info := stream.infos[0]
 	if len(stream.infos) > 1 {
-		stream.infos = stream.infos[1:]
+		copy(stream.infos[0:], stream.infos[1:])
+		stream.infos = stream.infos[:len(stream.infos)-1]
 		stream.size -= info.size
 		q.streams[longestIdx] = stream
 		q.size -= info.size
@@ -77,7 +78,8 @@ func (q *packetQueue) pop() (info pqPacketInfo, ok bool) {
 		stream := q.streams[0]
 		info = stream.infos[0]
 		if len(stream.infos) > 1 {
-			stream.infos = stream.infos[1:]
+			copy(stream.infos[0:], stream.infos[1:])
+			stream.infos = stream.infos[:len(stream.infos)-1]
 			stream.size -= info.size
 			q.streams[0] = stream
 			q.size -= info.size


### PR DESCRIPTION
By constantly head-trimming the slice (doing `slice = slice[1:]`), it is pretty much guaranteed that you will go out of the bounds of the underlying array, forcing a reallocation. This also creates more work for the GC.

By copying the slice entries up by one and tail-trimming the slice instead, we can often reuse the same underlying array capacity more often, reducing the allocation burden considerably.