### PR TITLE
Reduce allocations in `dhtTraffic` and `pathTraffic`

### DIFF
--- a/network/dhtree.go
+++ b/network/dhtree.go
@@ -653,7 +653,6 @@ func (t *dhtree) handleDHTTraffic(from phony.Actor, tr *dhtTraffic, doNotify boo
 				t.pathfinder._doNotify(dest, !doNotify)
 			}
 			t.core.pconn.handleTraffic(tr)
-			dhtTrafficPool.Put(tr)
 		} else {
 			next.sendDHTTraffic(t, tr)
 		}
@@ -1176,18 +1175,15 @@ func (t *dhtTraffic) encode(out []byte) ([]byte, error) {
 }
 
 func (t *dhtTraffic) decode(data []byte) error {
-	tmp := getDHTTraffic()
-	defer dhtTrafficPool.Put(tmp)
-	if !wireChopSlice(tmp.source[:], &data) {
+	if !wireChopSlice(t.source[:], &data) {
 		return wireDecodeError
-	} else if !wireChopSlice(tmp.dest[:], &data) {
+	} else if !wireChopSlice(t.dest[:], &data) {
 		return wireDecodeError
 	}
 	if len(data) < 1 {
 		return wireDecodeError
 	}
 	t.kind, data = data[0], data[1:]
-	t.source, t.dest = tmp.source, tmp.dest
 	t.payload = append(t.payload[:0], data...)
 	return nil
 }

--- a/network/packetconn.go
+++ b/network/packetconn.go
@@ -44,6 +44,20 @@ func (pc *PacketConn) init(c *core) {
 	pc.Debug.init(c)
 }
 
+var dhtTrafficPool = sync.Pool{
+	New: func() interface{} {
+		return &dhtTraffic{
+			payload: make([]byte, 0, 65535),
+		}
+	},
+}
+
+func getDHTTraffic() *dhtTraffic {
+	d := dhtTrafficPool.Get().(*dhtTraffic)
+	d.payload = d.payload[:0]
+	return d
+}
+
 // ReadFrom fulfills the net.PacketConn interface, with a types.Addr returned as the from address.
 // Note that failing to call ReadFrom may cause the connection to block and/or leak memory.
 func (pc *PacketConn) ReadFrom(p []byte) (n int, from net.Addr, err error) {
@@ -61,6 +75,7 @@ func (pc *PacketConn) ReadFrom(p []byte) (n int, from net.Addr, err error) {
 		n = len(p)
 	}
 	from = tr.source.addr()
+	dhtTrafficPool.Put(tr)
 	return
 }
 
@@ -81,12 +96,12 @@ func (pc *PacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 	if uint64(len(p)) > pc.MTU() {
 		return 0, errors.New("oversized message")
 	}
-	var tr dhtTraffic
+	tr := getDHTTraffic()
 	tr.source = pc.core.crypto.publicKey
 	copy(tr.dest[:], dest)
 	tr.kind = wireTrafficStandard
-	tr.payload = append(tr.payload, p...)
-	pc.core.dhtree.sendTraffic(nil, &tr)
+	tr.payload = append(tr.payload[:0], p...)
+	pc.core.dhtree.sendTraffic(nil, tr)
 	return len(p), nil
 }
 

--- a/network/packetqueue.go
+++ b/network/packetqueue.go
@@ -42,6 +42,14 @@ func (q *packetQueue) drop() bool {
 	}
 	stream := q.streams[longestIdx]
 	info := stream.infos[0]
+	if info.packet != nil {
+		switch tr := info.packet.(type) {
+		case *dhtTraffic:
+			defer dhtTrafficPool.Put(tr)
+		case *pathTraffic:
+			defer dhtTrafficPool.Put(tr.dt)
+		}
+	}
 	if len(stream.infos) > 1 {
 		stream.infos = stream.infos[1:]
 		stream.size -= info.size

--- a/network/pathfinder.go
+++ b/network/pathfinder.go
@@ -301,7 +301,7 @@ func (r *pathResponse) decode(data []byte) error {
 
 type pathTraffic struct {
 	path []peerPort
-	dt   dhtTraffic
+	dt   *dhtTraffic
 }
 
 func (t *pathTraffic) encode(out []byte) ([]byte, error) {
@@ -311,12 +311,18 @@ func (t *pathTraffic) encode(out []byte) ([]byte, error) {
 
 func (t *pathTraffic) decode(data []byte) error {
 	var tmp pathTraffic
+	tmp.dt = getDHTTraffic()
+	defer dhtTrafficPool.Put(tmp.dt)
 	if !wireChopPath(&tmp.path, &data) {
 		return wireDecodeError
 	} else if err := tmp.dt.decode(data); err != nil {
 		return err
 	}
 	*t = tmp
+	t.path = tmp.path
+	t.dt.source, t.dt.dest = tmp.dt.source, tmp.dt.dest
+	t.dt.kind = tmp.dt.kind
+	t.dt.payload = append(t.dt.payload[:0], tmp.dt.payload...)
 	return nil
 }
 

--- a/network/pathfinder.go
+++ b/network/pathfinder.go
@@ -310,20 +310,10 @@ func (t *pathTraffic) encode(out []byte) ([]byte, error) {
 }
 
 func (t *pathTraffic) decode(data []byte) error {
-	var tmp pathTraffic
-	tmp.dt = getDHTTraffic()
-	defer dhtTrafficPool.Put(tmp.dt)
-	if !wireChopPath(&tmp.path, &data) {
+	if !wireChopPath(&t.path, &data) {
 		return wireDecodeError
-	} else if err := tmp.dt.decode(data); err != nil {
-		return err
 	}
-	*t = tmp
-	t.path = tmp.path
-	t.dt.source, t.dt.dest = tmp.dt.source, tmp.dt.dest
-	t.dt.kind = tmp.dt.kind
-	t.dt.payload = append(t.dt.payload[:0], tmp.dt.payload...)
-	return nil
+	return t.dt.decode(data)
 }
 
 func pathPopFirstHop(data []byte) (peerPort, []byte) {

--- a/network/peers.go
+++ b/network/peers.go
@@ -400,6 +400,7 @@ func (p *peer) sendDHTTraffic(from phony.Actor, tr *dhtTraffic) {
 
 func (p *peer) _handlePathTraffic(bs []byte) error {
 	tr := new(pathTraffic)
+	tr.dt = getDHTTraffic()
 	if err := tr.decode(bs); err != nil {
 		return err
 	}
@@ -419,7 +420,7 @@ func (ps *peers) handlePathTraffic(from phony.Actor, tr *pathTraffic) {
 			next.sendPathTraffic(nil, tr)
 		} else {
 			// Fall back to dhtTraffic
-			ps.core.dhtree.handleDHTTraffic(ps, &tr.dt, false)
+			ps.core.dhtree.handleDHTTraffic(ps, tr.dt, false)
 		}
 	})
 }
@@ -476,11 +477,13 @@ func (p *peer) _push(packet wireEncodeable) {
 func (p *peer) pop() {
 	p.Act(nil, func() {
 		if info, ok := p.queue.pop(); ok {
-			switch info.packet.(type) {
+			switch tr := info.packet.(type) {
 			case *dhtTraffic:
 				p.writer.sendPacket(wireDHTTraffic, info.packet)
+				dhtTrafficPool.Put(tr)
 			case *pathTraffic:
 				p.writer.sendPacket(wirePathTraffic, info.packet)
+				dhtTrafficPool.Put(tr.dt)
 			default:
 				panic("this should never happen")
 			}


### PR DESCRIPTION
This takes allocations on a loaded test case with encryption disabled from 850MB down to 210MB.