### PR TITLE
Fix some data races

### DIFF
--- a/encrypted/session.go
+++ b/encrypted/session.go
@@ -424,7 +424,7 @@ func (info *sessionInfo) _sendInit() {
 	info.mgr.sendInit(&info.ed, &init)
 }
 
-func (info sessionInfo) _sendAck() {
+func (info *sessionInfo) _sendAck() {
 	init := newSessionInit(&info.sendPub, &info.nextPub, info.localKeySeq)
 	ack := sessionAck{init}
 	info.mgr.sendAck(&info.ed, &ack)

--- a/network/packetconn.go
+++ b/network/packetconn.go
@@ -54,6 +54,9 @@ var dhtTrafficPool = sync.Pool{
 
 func getDHTTraffic() *dhtTraffic {
 	d := dhtTrafficPool.Get().(*dhtTraffic)
+	d.kind = wireDummy
+	d.source = publicKey{}
+	d.dest = publicKey{}
 	d.payload = d.payload[:0]
 	return d
 }
@@ -278,6 +281,7 @@ func (pc *PacketConn) handleTraffic(tr *dhtTraffic) {
 				// TODO something smarter than spamming goroutines
 				go pc.oobHandler(source, dest, msg)
 			}
+			dhtTrafficPool.Put(tr)
 		default:
 			// Drop the traffic
 			dhtTrafficPool.Put(tr)


### PR DESCRIPTION
This fixes a couple data races, one or two introduced accidentally by #15, and one in `encrypted` which was there before apparently.