### PR TITLE
Rotate keys no more than every minute

### DIFF
--- a/encrypted/session.go
+++ b/encrypted/session.go
@@ -212,6 +212,7 @@ type sessionInfo struct {
 	timer        *time.Timer
 	ack          *sessionAck
 	since        time.Time
+	rotated      time.Time // last time we rotated keys
 	rx           uint64
 	tx           uint64
 }
@@ -407,7 +408,10 @@ func (info *sessionInfo) doRecv(from phony.Actor, msg []byte) {
 			msg = unboxed[len(key):]
 			info.mgr.pc.network.recv(info, msg)
 			// Misc remaining followup work
-			onSuccess(key)
+			if time.Since(info.rotated) > time.Minute {
+				onSuccess(key)
+				info.rotated = time.Now()
+			}
 			info.rx += uint64(len(msg))
 			info._resetTimer()
 		} else {

--- a/encrypted/session.go
+++ b/encrypted/session.go
@@ -408,7 +408,7 @@ func (info *sessionInfo) doRecv(from phony.Actor, msg []byte) {
 			msg = unboxed[len(key):]
 			info.mgr.pc.network.recv(info, msg)
 			// Misc remaining followup work
-			if time.Since(info.rotated) > time.Minute {
+			if info.rotated.IsZero() || time.Since(info.rotated) > time.Minute {
 				onSuccess(key)
 				info.rotated = time.Now()
 			}


### PR DESCRIPTION
Currently rotating keys based on round-trips alone means we spend a lot of time generating new keys and that slows traffic down on local LANs. By only rotating keys at most once a minute, transfer speeds should be better.