### PR TITLE
Populate sequence and timestamp in bad news messages

### DIFF
--- a/network/dhtree.go
+++ b/network/dhtree.go
@@ -108,7 +108,11 @@ func (t *dhtree) update(from phony.Actor, info *treeInfo, p *peer) {
 				//  Then we get more bad news and switch again, etc...
 				// Set self to root, send, then process things correctly 1 second later
 				t.wait = true
-				t.self = &treeInfo{root: t.core.crypto.publicKey}
+				t.self = &treeInfo{
+					root: t.core.crypto.publicKey,
+					seq:  uint64(time.Now().Unix()),
+					time: time.Now(),
+				}
 				t._sendTree() // send bad news immediately
 				time.AfterFunc(peerTIMEOUT+time.Second, func() {
 					t.Act(nil, func() {


### PR DESCRIPTION
When we send bad news to other nodes in response to a missing parent, we don't populate the sequence number, so it will always be encoded to `0`.

Those updates may end up looking worse than entries in the expired map in `_fix` causing those peers to be ignored in parent selection, which may delay the tree repairing itself.