### PR TITLE
Avoid selecting flakey parents

### DIFF
--- a/network/packetconn.go
+++ b/network/packetconn.go
@@ -181,7 +181,7 @@ func (pc *PacketConn) HandleConn(key ed25519.PublicKey, conn net.Conn, prio uint
 		return err
 	}
 	err = p.handler()
-	if e := pc.core.peers.removePeer(p.port); e != nil {
+	if e := pc.core.peers.removePeer(p.port, pk); e != nil {
 		return e
 	}
 	return err


### PR DESCRIPTION
Automatically punishes nodes during parent selection that have disconnected a lot recently.

This hurts mobility2 a bit but might help to reduce some of the problems that the v0.4 network sees today.