### PR TITLE
Tweak byte and traffic pools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Arceliar/ironwood
 
-go 1.15
+go 1.17
 
 require (
 	github.com/Arceliar/phony v0.0.0-20210209235338-dde1a8dca979


### PR DESCRIPTION
`sync.Pool` performs best when everything is pointer-like, to prevent excess allocations from creating additional slice headers. It also makes sense for each buffer to have the same underlying capacity, so that we don't have to discard smaller-than-needed buffers in `allocBytes` which wastes further allocations.

This also bumps up to Go 1.17 because that's required to convert slices back into byte arrays.