### PR TITLE
Block on session sends to prevent excessive memory usage

### DIFF
--- a/encrypted/session.go
+++ b/encrypted/session.go
@@ -143,7 +143,7 @@ func (mgr *sessionManager) _handleTraffic(pub *edPub, msg []byte) {
 }
 
 func (mgr *sessionManager) writeTo(toKey edPub, msg []byte) {
-	mgr.Act(nil, func() {
+	phony.Block(mgr, func() {
 		if info := mgr.sessions[toKey]; info != nil {
 			info.doSend(mgr, msg)
 		} else {
@@ -293,7 +293,7 @@ func (info *sessionInfo) _handleUpdate(init *sessionInit) {
 
 func (info *sessionInfo) doSend(from phony.Actor, msg []byte) {
 	// TODO? some worker pool to multi-thread this
-	info.Act(from, func() {
+	phony.Block(info, func() {
 		defer info.mgr.pool.Put(msg[:0]) // nolint:staticcheck
 		info.sendNonce += 1              // Advance the nonce before anything else
 		if info.sendNonce == 0 {


### PR DESCRIPTION
Sending a large volume of traffic at once can cause the `sessionInfo` inboxes to grow without bounds. We end up holding onto all of the buffer heap references while the underlying `PacketConn` struggles to process the traffic in time, which causes memory usage to shoot up and eventually we get OOM'd, like in yggdrasil-network/yggdrasil-go#1026.

This doesn't really happen with TCP flows because congestion control does the right thing but it can be easily reproduced by trying to send more UDP traffic than the underlying `PacketConn` can handle. By blocking instead, we force writers to slow down to the speed of the underlying `PacketConn` and this stops memory usage ballooning out of control. 

This should be safe to cherry-pick into the `softcrdt` branch too.