### PR TITLE
Use pointerised slices in `sync.Pool`s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Arceliar/ironwood
 
-go 1.15
+go 1.17
 
 require (
 	github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d

--- a/network/pool.go
+++ b/network/pool.go
@@ -2,21 +2,32 @@ package network
 
 import "sync"
 
-var bytePool = sync.Pool{New: func() interface{} { return []byte(nil) }}
+const byteSize = 65535 * 2
+
+type byteSlice [byteSize]byte
+
+var bytePool = sync.Pool{
+	New: func() interface{} {
+		b := byteSlice{}
+		return &b
+	},
+}
 
 func allocBytes(size int) []byte {
-	bs := bytePool.Get().([]byte)
-	if cap(bs) < size {
-		bs = make([]byte, size)
-	}
+	bs := bytePool.Get().(*byteSlice)
 	return bs[:size]
 }
 
 func freeBytes(bs []byte) {
-	bytePool.Put(bs[:0]) //nolint:staticcheck
+	bu := (*byteSlice)(bs[:byteSize])
+	bytePool.Put(bu)
 }
 
-var trafficPool = sync.Pool{New: func() interface{} { return new(traffic) }}
+var trafficPool = sync.Pool{
+	New: func() interface{} {
+		return new(traffic)
+	},
+}
 
 func allocTraffic() *traffic {
 	tr := trafficPool.Get().(*traffic)


### PR DESCRIPTION
According to pprof, this seemingly reduces minor allocations further.

I don't know what the best values for `byteSize` in both `network` and `encrypted` really are, but these seem to work for now.