### PR TITLE
Use counter for peer connection ordering instead of timestamp

### DIFF
--- a/network/router.go
+++ b/network/router.go
@@ -682,7 +682,7 @@ func (r *router) _lookup(path []peerPort, watermark *uint64) *peer {
 				case bestPeer != nil && p.prio > bestPeer.prio:
 					// Skip worse priority links
 					continue
-				case bestPeer != nil && p.time.After(bestPeer.time):
+				case bestPeer != nil && p.order > bestPeer.order:
 					// Skip links that have been up for less time
 					continue
 				default:


### PR DESCRIPTION
In cases where time resolution is bad, this might cause the equal priority tiebreak to act unpredictably. 