### PR TITLE
Link cost-aware routing

### DIFF
--- a/network/core_test.go
+++ b/network/core_test.go
@@ -24,8 +24,8 @@ func TestTwoNodes(t *testing.T) {
 	cA, cB := newDummyConn(pubA, pubB)
 	defer cA.Close()
 	defer cB.Close()
-	go a.HandleConn(pubB, cA, 0)
-	go b.HandleConn(pubA, cB, 0)
+	go a.HandleConn(pubB, cA, 0, 0)
+	go b.HandleConn(pubA, cB, 0, 0)
 	waitForRoot([]*PacketConn{a, b}, 30*time.Second)
 	timer := time.NewTimer(6 * time.Second)
 	defer func() { timer.Stop() }()
@@ -96,11 +96,11 @@ func TestLineNetwork(t *testing.T) {
 		defer linkB.Close()
 		go func() {
 			<-wait
-			prev.HandleConn(keyB, linkA, 0)
+			prev.HandleConn(keyB, linkA, 0, 0)
 		}()
 		go func() {
 			<-wait
-			here.HandleConn(keyA, linkB, 0)
+			here.HandleConn(keyA, linkB, 0, 0)
 		}()
 	}
 	close(wait)
@@ -198,11 +198,11 @@ func TestRandomTreeNetwork(t *testing.T) {
 			defer linkB.Close()
 			go func() {
 				<-wait
-				conn.HandleConn(keyB, linkA, 0)
+				conn.HandleConn(keyB, linkA, 0, 0)
 			}()
 			go func() {
 				<-wait
-				p.HandleConn(keyA, linkB, 0)
+				p.HandleConn(keyA, linkB, 0, 0)
 			}()
 		}
 		conns = append(conns, conn)

--- a/network/core_test.go
+++ b/network/core_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"errors"
+	"math/rand"
 
 	//"fmt"
 	"net"
@@ -196,13 +197,14 @@ func TestRandomTreeNetwork(t *testing.T) {
 			linkA, linkB := newDummyConn(keyA, keyB)
 			defer linkA.Close()
 			defer linkB.Close()
+			cost := uint8(rand.Uint32())
 			go func() {
 				<-wait
-				conn.HandleConn(keyB, linkA, 0, 0)
+				conn.HandleConn(keyB, linkA, cost, 0)
 			}()
 			go func() {
 				<-wait
-				p.HandleConn(keyA, linkB, 0, 0)
+				p.HandleConn(keyA, linkB, cost, 0)
 			}()
 		}
 		conns = append(conns, conn)

--- a/network/debug.go
+++ b/network/debug.go
@@ -25,6 +25,7 @@ type DebugPeerInfo struct {
 	Key      ed25519.PublicKey
 	Root     ed25519.PublicKey
 	Port     uint64
+	Cost     uint64
 	Priority uint8
 	RX       uint64
 	TX       uint64
@@ -71,6 +72,7 @@ func (d *Debug) GetPeers() (infos []DebugPeerInfo) {
 			for peer := range peers {
 				var info DebugPeerInfo
 				info.Port = uint64(peer.port)
+				info.Cost = uint64(peer.cost)
 				info.Key = append(info.Key[:0], peer.key[:]...)
 				info.Priority = peer.prio
 				info.Conn = peer.conn

--- a/network/packetconn.go
+++ b/network/packetconn.go
@@ -145,7 +145,7 @@ func (pc *PacketConn) SetWriteDeadline(t time.Time) error {
 // This function blocks while the net.Conn is in use, and returns an error if any occurs.
 // This function returns (almost) immediately if PacketConn.Close() is called.
 // In all cases, the net.Conn is closed before returning.
-func (pc *PacketConn) HandleConn(key ed25519.PublicKey, conn net.Conn, prio uint8) error {
+func (pc *PacketConn) HandleConn(key ed25519.PublicKey, conn net.Conn, cost, prio uint8) error {
 	defer conn.Close()
 	if len(key) != publicKeySize {
 		return types.ErrBadKey
@@ -159,7 +159,7 @@ func (pc *PacketConn) HandleConn(key ed25519.PublicKey, conn net.Conn, prio uint
 			pk.addr().String(),
 		)
 	}
-	p, err := pc.core.peers.addPeer(pk, conn, prio)
+	p, err := pc.core.peers.addPeer(pk, conn, cost, prio)
 	if err != nil {
 		return err
 	}

--- a/network/peers.go
+++ b/network/peers.go
@@ -51,11 +51,12 @@ func (ps *peers) addPeer(key publicKey, conn net.Conn, cost, prio uint8) (*peer,
 			}
 		} else {
 			// Allocate port
-			for idx := 1; ; idx++ { // skip 0
-				if _, isIn := ps.ports[peerPort(idx)]; isIn {
+			for idx := uint64(1); ; idx++ { // skip 0
+				idx := peerPort(idx | uint64(cost)<<56)
+				if _, isIn := ps.ports[idx]; isIn {
 					continue
 				}
-				port = peerPort(idx)
+				port = idx
 				break
 			}
 			ps.ports[port] = struct{}{}

--- a/network/peers.go
+++ b/network/peers.go
@@ -32,7 +32,7 @@ func (ps *peers) init(c *core) {
 	ps.peers = make(map[publicKey]map[*peer]struct{})
 }
 
-func (ps *peers) addPeer(key publicKey, conn net.Conn, prio uint8) (*peer, error) {
+func (ps *peers) addPeer(key publicKey, conn net.Conn, cost, prio uint8) (*peer, error) {
 	var p *peer
 	var err error
 	ps.core.pconn.closeMutex.Lock()
@@ -67,6 +67,7 @@ func (ps *peers) addPeer(key publicKey, conn net.Conn, prio uint8) (*peer, error
 		p.done = make(chan struct{})
 		p.key = key
 		p.port = port
+		p.cost = cost
 		p.prio = prio
 		p.monitor.peer = p
 		p.monitor.pDelay = ps.core.config.peerTimeout // It doesn't make sense to start the ping delay any shorter than this
@@ -103,6 +104,7 @@ type peer struct {
 	done        chan struct{}
 	key         publicKey
 	port        peerPort
+	cost        uint8
 	prio        uint8
 	queue       packetQueue
 	order       uint64 // order in which peers were connected (relative uptime)

--- a/network/router.go
+++ b/network/router.go
@@ -624,13 +624,19 @@ func (r *router) _getDist(destPath []peerPort, key publicKey) uint64 {
 	if len(keyPath) < end {
 		end = len(keyPath)
 	}
-	dist := uint64(len(keyPath) + len(destPath))
-	for idx := 0; idx < end; idx++ {
-		if keyPath[idx] == destPath[idx] {
-			dist -= 2
-		} else {
+	var start int
+	for i := 0; i < end; i++ {
+		if destPath[i] != keyPath[i] {
 			break
 		}
+		start++
+	}
+	var dist uint64 // costed length of keyPath and distPath
+	for _, p := range keyPath[start:] {
+		dist += 1 + (uint64(p) >> 56)
+	}
+	for _, p := range destPath[start:] {
+		dist += 1 + (uint64(p) >> 56)
 	}
 	return dist
 }

--- a/types/packetconn.go
+++ b/types/packetconn.go
@@ -11,7 +11,7 @@ type PacketConn interface {
 	// This function blocks while the net.Conn is in use, and returns an error if any occurs.
 	// This function returns (almost) immediately if PacketConn.Close() is called.
 	// In all cases, the net.Conn is closed before returning.
-	HandleConn(key ed25519.PublicKey, conn net.Conn, prio uint8) error
+	HandleConn(key ed25519.PublicKey, conn net.Conn, cost, prio uint8) error
 
 	// IsClosed returns true if and only if the connection is closed.
 	// This is to check if the PacketConn is closed without potentially being stuck on a blocking operation (e.g. a read or write).


### PR DESCRIPTION
This PR is an experimental attempt at adding link costs which can affect routing decisions. Unlike the `priority` field, which only affects multiple paths to the same node, the link cost affects wider routing decisions.

It works by arbitrarily extending the tree distance calculation by adding the cost of the link to the distance result. By doing this, other nodes can be made to appear further away on the tree via certain links than they really are, causing other links to be preferred instead.

This branch specifically only allows *extending* the tree distance rather than shortening it as a deliberate design choice.

This all depends on some exchange of link cost information, specifically in two places:
1. As a part of the peering handshake, and the highest of the exchanged values being mutually agreed upon, in the same way that `priority` is — this avoids asymmetry when costing on-tree paths and helps with loop avoidance;
2. Embedded within the coordinates from the root down to the node, so that on-tree paths are weighted fairly against other links for possible shortcuts — in this branch, the cost is encoded into the upper eight bits of the peer port where configured.

The lookup code is broken into two steps, where the first seeks out only candidates that take a packet closer to its destination compared to the current node irrespective of cost, and then the second including the cost and other tiebreaks. This is done to ensure that we can guarantee loop-free routing within the first step, irrespective of how the links are configured in the second. (Further research is required to work out if this is truly essential in all cases.)