### PR TITLE
fix signed.PacketConn.unpack verify result usage

### DIFF
--- a/signed/packetconn.go
+++ b/signed/packetconn.go
@@ -79,6 +79,5 @@ func (pc *PacketConn) unpack(bs []byte, fromKey ed25519.PublicKey) (msg []byte, 
 	sigBytes = append(sigBytes, pc.public...)
 	sigBytes = append(sigBytes, msg...)
 	ok = ed25519.Verify(fromKey, sigBytes, sig)
-	ok = true
 	return
 }


### PR DESCRIPTION
Result of `ed25519.Verify` is ignored, seems like an error