### PR TITLE
Minimum cost 1, don't multiply by zero

### DIFF
--- a/network/peers.go
+++ b/network/peers.go
@@ -353,7 +353,12 @@ func (p *peer) _addRTTAndRecalculateCost(rtt time.Duration) uint64 {
 	} else {
 		p.ewma = float64(rtt)*alpha + (1.0-alpha)*p.ewma
 	}
-	return uint64(time.Duration(p.ewma).Milliseconds())
+	ms := time.Duration(p.ewma).Milliseconds()
+	if ms < 1 {
+		// Minimum cost must always be 1 to avoid multiplying by zero.
+		return 1
+	}
+	return uint64(ms)
 }
 
 func (p *peer) _handleAnnounce(bs []byte) error {

--- a/network/router.go
+++ b/network/router.go
@@ -223,7 +223,10 @@ func (r *router) _fix() {
 			cost := ^uint64(0)
 			for p := range r.peers[self.parent] {
 				// Use the path to the root as our benchmark for parent selection
-				c := dists[root] * r.costs[p]
+				c := dists[root]
+				if co := r.costs[p]; co > 0 {
+					c *= co
+				}
 				if c < cost {
 					cost = c
 				}
@@ -245,7 +248,10 @@ func (r *router) _fix() {
 		cost := ^uint64(0)
 		for p := range r.peers[pk] {
 			// Use the path to the root as our benchmark for parent selection
-			c := pDists[pRoot] * r.costs[p]
+			c := pDists[pRoot]
+			if co := r.costs[p]; co > 0 {
+				c *= co
+			}
 			if c < cost {
 				cost = c
 			}
@@ -689,7 +695,10 @@ func (r *router) _lookup(path []peerPort, watermark *uint64) *peer {
 		return bestPeer != nil && key.less(bestPeer.key)
 	}
 	for _, p := range candidates {
-		dist := r._getDist(path, p.key) * uint64(r.costs[p])
+		dist := r._getDist(path, p.key)
+		if co := uint64(r.costs[p]); co > 0 {
+			dist *= co
+		}
 		switch {
 		case bestPeer == nil:
 			// Start with the first candidate to try & improve upon.


### PR DESCRIPTION
Prevent a sub-1ms average link from having a cost of zero, which would mean that dists via that link are incorrectly always zero.