### PR TITLE
Reduce allocations

### DIFF
--- a/network/router.go
+++ b/network/router.go
@@ -753,16 +753,16 @@ func (r *router) _lookup(path []peerPort, watermark *uint64) *peer {
 
 func (r *router) _getAncestry(key publicKey) []publicKey {
 	// Returns the ancestry starting with the root side, ordering is important for how we send over the network / GC info...
-	anc := r._backwardsAncestry(key)
+	var _anc [32]publicKey
+	anc := r._backwardsAncestry(_anc[:0], key)
 	for left, right := 0, len(anc)-1; left < right; left, right = left+1, right-1 {
 		anc[left], anc[right] = anc[right], anc[left]
 	}
 	return anc
 }
 
-func (r *router) _backwardsAncestry(key publicKey) []publicKey {
+func (r *router) _backwardsAncestry(anc []publicKey, key publicKey) []publicKey {
 	// Return an ordered list of node ancestry, starting with the given key and ending at the root (or the end of the line)
-	var anc []publicKey
 	here := key
 	for {
 		// TODO? use a map or something to check visited nodes faster?

--- a/network/wire.go
+++ b/network/wire.go
@@ -85,7 +85,7 @@ func wireAppendPath(dest []byte, path []peerPort) []byte {
 	return dest
 }
 
-func wireDecodePath(source []byte) (path []peerPort, length int) {
+func wireDecodePath(path []peerPort, source []byte) ([]peerPort, int) {
 	bs := source
 	for {
 		var u uint64
@@ -97,12 +97,13 @@ func wireDecodePath(source []byte) (path []peerPort, length int) {
 		}
 		path = append(path, peerPort(u))
 	}
-	length = len(source) - len(bs)
-	return
+	length := len(source) - len(bs)
+	return path, length
 }
 
 func wireChopPath(out *[]peerPort, data *[]byte) bool {
-	path, length := wireDecodePath(*data)
+	var _path [128]peerPort
+	path, length := wireDecodePath(_path[:0], *data)
 	if length < 0 {
 		return false
 	}


### PR DESCRIPTION
In a couple of places on the hot paths, we can avoid heap escapes by passing down our own arrays on the stack. 