### PR TITLE
Deficit round robin (DRR) packet queue

### DIFF
--- a/network/config.go
+++ b/network/config.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const defaultMaxMessageSize = 1048576 // 1 megabyte
+
 type config struct {
 	routerRefresh      time.Duration
 	routerTimeout      time.Duration
@@ -25,7 +27,7 @@ func configDefaults() Option {
 		c.routerTimeout = 5 * time.Minute
 		c.peerKeepAliveDelay = time.Second
 		c.peerTimeout = 3 * time.Second
-		c.peerMaxMessageSize = 1048576 // 1 megabyte
+		c.peerMaxMessageSize = defaultMaxMessageSize
 		c.bloomTransform = func(key ed25519.PublicKey) ed25519.PublicKey { return key }
 		c.pathNotify = func(key ed25519.PublicKey) {}
 		c.pathTimeout = time.Minute

--- a/network/packetconn.go
+++ b/network/packetconn.go
@@ -40,6 +40,7 @@ func NewPacketConn(secret ed25519.PrivateKey, options ...Option) (*PacketConn, e
 func (pc *PacketConn) init(c *core) {
 	pc.core = c
 	pc.recv = make(chan *traffic, 1)
+	pc.recvq.init(c.config.peerMaxMessageSize)
 	pc.readDeadline = newDeadline()
 	pc.closed = make(chan struct{})
 	pc.Debug.init(c)

--- a/network/packetqueue.go
+++ b/network/packetqueue.go
@@ -1,8 +1,12 @@
 package network
 
 import (
-	"container/heap"
 	"time"
+)
+
+const (
+	defaultPacketQueueMaxBytesMultiplier = 16
+	defaultPacketQueuePerFlowMultiplier  = 4
 )
 
 type pqPacket interface {
@@ -18,199 +22,231 @@ type pqPacketInfo struct {
 	time   time.Time
 }
 
-type pqSource struct {
-	key   publicKey
-	infos []pqPacketInfo
-	size  uint64
+type pqFlowKey struct {
+	source publicKey // Original sender for this queued flow
+	dest   publicKey // Intended receiver for this queued flow
 }
 
-type pqDest struct {
-	key     publicKey
-	sources []pqSource
-	size    uint64
+type pqFlow struct {
+	key     pqFlowKey      // Stable flow identity used in the queue map
+	infos   []pqPacketInfo // FIFO packet backlog for this flow
+	size    uint64         // Total queued bytes currently held by this flow
+	deficit uint64         // DRR credit used to decide which flow can send next
+	index   int            // Position in q.active or -1 when inactive
 }
 
 type packetQueue struct {
-	dests []pqDest
-	size  uint64
+	flows           map[pqFlowKey]*pqFlow // All known flows, keyed by source/dest pair
+	active          []*pqFlow             // Flows that currently have queued packets
+	next            int                   // Round-robin cursor into active flows
+	size            uint64                // Total queued bytes across all active flows
+	maxBytesTotal   uint64                // Hard cap for total queued bytes
+	maxBytesPerFlow uint64                // Hard cap for bytes a single flow may hold
+	quantum         uint64                // DRR byte budget added to a flow each round
 }
 
-// drop will remove a packet from the queue
-// the packet removed will be the oldest packet from the longest stream to the largest destination queue
-// returns true if a packet was removed, false otherwise
-func (q *packetQueue) drop() bool {
-	if q.size == 0 {
-		return false
+func (q *packetQueue) init(pmtu uint64) {
+	if pmtu == 0 {
+		pmtu = defaultMaxMessageSize
 	}
-	var dIdx int
-	for idx := range q.dests {
-		if q.dests[idx].size > q.dests[dIdx].size {
-			dIdx = idx
-		}
+	q.flows = make(map[pqFlowKey]*pqFlow)
+	q.next = -1
+	q.quantum = pmtu
+	q.maxBytesTotal = q.quantum * defaultPacketQueueMaxBytesMultiplier
+	q.maxBytesPerFlow = q.quantum * defaultPacketQueuePerFlowMultiplier
+}
+
+func (q *packetQueue) activate(flow *pqFlow) {
+	flow.index = len(q.active)
+	q.active = append(q.active, flow)
+}
+
+func (q *packetQueue) deactivate(flow *pqFlow) {
+	idx := flow.index
+	last := len(q.active) - 1
+	if idx < 0 || idx > last {
+		return
 	}
-	dest := q.dests[dIdx]
-	var sIdx int
-	for idx := range dest.sources {
-		if dest.sources[idx].size > dest.sources[sIdx].size {
-			sIdx = idx
-		}
+	if idx != last {
+		moved := q.active[last]
+		q.active[idx] = moved
+		moved.index = idx
 	}
-	source := dest.sources[sIdx]
-	info := source.infos[0]
-	source.size -= info.size
-	if len(source.infos) > 0 {
-		source.infos = source.infos[1:]
+	q.active[last] = nil
+	q.active = q.active[:last]
+	flow.index = -1
+	if len(q.active) == 0 {
+		q.next = -1
+		return
 	}
-	dest.sources[sIdx] = source
-	if source.size > 0 {
-		heap.Fix(&dest, sIdx)
-	} else {
-		heap.Remove(&dest, sIdx)
+	if q.next == last {
+		q.next = idx
 	}
-	dest.size -= info.size
-	q.dests[dIdx] = dest
-	if dest.size > 0 {
-		heap.Fix(q, dIdx)
-	} else {
-		heap.Remove(q, dIdx)
+	if q.next >= len(q.active) {
+		q.next = 0
 	}
+}
+
+func (q *packetQueue) flowFor(packet pqPacket) *pqFlow {
+	key := pqFlowKey{source: packet.sourceKey(), dest: packet.destKey()}
+	if flow, ok := q.flows[key]; ok {
+		return flow
+	}
+	flow := &pqFlow{key: key, index: -1}
+	q.flows[key] = flow
+	return flow
+}
+
+func (q *packetQueue) removeFlowIfEmpty(flow *pqFlow) {
+	if len(flow.infos) != 0 {
+		return
+	}
+	if flow.index >= 0 {
+		q.deactivate(flow)
+	}
+	delete(q.flows, flow.key)
+}
+
+func (q *packetQueue) dropFrom(flow *pqFlow) (pqPacketInfo, bool) {
+	if flow == nil || len(flow.infos) == 0 {
+		return pqPacketInfo{}, false
+	}
+	info := flow.infos[0]
+	n := copy(flow.infos, flow.infos[1:])
+	flow.infos[n] = pqPacketInfo{}
+	flow.infos = flow.infos[:n]
+	flow.size -= info.size
 	q.size -= info.size
-	switch p := info.packet.(type) {
+	if flow.deficit > q.quantum*4 {
+		flow.deficit = q.quantum * 4
+	}
+	q.removeFlowIfEmpty(flow)
+	return info, true
+}
+
+func (q *packetQueue) largestFlow() *pqFlow {
+	var victim *pqFlow
+	for _, flow := range q.active {
+		if victim == nil || flow.size > victim.size ||
+			(flow.size == victim.size && flow.infos[0].time.Before(victim.infos[0].time)) {
+			victim = flow
+		}
+	}
+	return victim
+}
+
+func freePQPacket(packet pqPacket) {
+	switch p := packet.(type) {
 	case *traffic:
 		freeTraffic(p)
 	default:
 		// Nothing to do
 	}
+}
+
+// drop will remove a packet from the queue.
+// The packet removed will be the oldest packet from the largest flow.
+// Returns true if a packet was removed, false otherwise.
+func (q *packetQueue) drop() bool {
+	if q.size == 0 {
+		return false
+	}
+	victim := q.largestFlow()
+	info, ok := q.dropFrom(victim)
+	if !ok {
+		return false
+	}
+	freePQPacket(info.packet)
 	return true
 }
 
-// push adds a packet with the provided size to a queue for the provided source and destination keys
-// a new queue will be created if needed
+// push adds a packet with the provided size to a flow-specific queue.
+// The queue is hard-bounded in bytes globally and per flow.
 func (q *packetQueue) push(packet pqPacket) {
-	sKey := packet.sourceKey()
-	dKey := packet.destKey()
-	size := packet.size()
-	info := pqPacketInfo{packet: packet, size: uint64(size), time: time.Now()}
-	sIdx, dIdx := -1, -1
-	source, dest := pqSource{key: sKey}, pqDest{key: dKey}
-	for idx, d := range q.dests {
-		if d.key.equal(dKey) {
-			dIdx, dest = idx, d
-			break
+	upsz := uint64(packet.size())
+	if upsz > q.maxBytesTotal || upsz > q.maxBytesPerFlow {
+		freePQPacket(packet)
+		return
+	}
+	info := pqPacketInfo{
+		packet: packet,
+		size:   upsz,
+		time:   time.Now(),
+	}
+	// Check that we aren't overflowing that particular queue.
+	flow := q.flowFor(packet)
+	for flow.size+info.size > q.maxBytesPerFlow && len(flow.infos) > 0 {
+		dropped, ok := q.dropFrom(flow)
+		if !ok {
+			freePQPacket(packet)
+			return
+		}
+		freePQPacket(dropped.packet)
+	}
+	// Check that we aren't overflowing the maximum queued total.
+	for q.size+info.size > q.maxBytesTotal && q.size > 0 {
+		if !q.drop() {
+			freePQPacket(packet)
+			return
 		}
 	}
-	for idx, s := range dest.sources {
-		if s.key.equal(sKey) {
-			sIdx, source = idx, s
-			break
-		}
-	}
-	source.infos = append(source.infos, info)
-	source.size += info.size
-	if sIdx < 0 {
-		dest.sources = append(dest.sources, source)
-	} else {
-		dest.sources[sIdx] = source
-	}
-	dest.size += info.size
-	if dIdx < 0 {
-		q.dests = append(q.dests, dest)
-	} else {
-		q.dests[dIdx] = dest
-	}
+	// The flow may have been removed while making room above; reacquire the
+	// registered flow before appending the new packet.
+	flow = q.flowFor(packet)
+	flow.infos = append(flow.infos, info)
+	flow.size += info.size
 	q.size += info.size
+	if flow.index < 0 {
+		q.activate(flow)
+	}
 }
 
-// pop removes and returns the oldest packet (from across all source/destination pairs)
+// pop removes and returns the next packet using deficit round robin across flows.
 func (q *packetQueue) pop() (info pqPacketInfo, ok bool) {
-	if q.size > 0 {
-		dest := q.dests[0]
-		source := dest.sources[0]
-		info = source.infos[0]
-		source.size -= info.size
-		dest.size -= info.size
-		q.size -= info.size
-		if len(source.infos) > 1 {
-			source.infos = source.infos[1:]
-			dest.sources[0] = source
-			heap.Fix(&dest, 0)
-		} else {
-			dest.sources[0] = source
-			heap.Remove(&dest, 0)
-		}
-		if len(dest.sources) > 0 {
-			q.dests[0] = dest
-			heap.Fix(q, 0)
-		} else {
-			q.dests[0] = dest
-			heap.Remove(q, 0)
-		}
-		return info, true
+	if q.size == 0 || len(q.active) == 0 {
+		q.next = -1
+		return
 	}
-	return
+	needCredit := false
+	if q.next < 0 {
+		q.next = 0
+		needCredit = true
+	} else if q.next >= len(q.active) {
+		q.next = 0
+	}
+	flow := q.active[q.next]
+	if needCredit {
+		flow.deficit += q.quantum
+	}
+	for {
+		if len(flow.infos) > 0 && flow.infos[0].size <= flow.deficit {
+			info, ok := q.dropFrom(flow)
+			if ok {
+				flow.deficit -= info.size
+			}
+			return info, ok
+		}
+		if q.next++; q.next >= len(q.active) {
+			q.next = 0
+		}
+		flow = q.active[q.next]
+		flow.deficit += q.quantum
+	}
 }
 
 func (q *packetQueue) peek() (info pqPacketInfo, ok bool) {
-	if len(q.dests) > 0 {
-		return q.dests[0].sources[0].infos[0], true
+	var oldest *pqPacketInfo
+	for _, flow := range q.active {
+		if len(flow.infos) == 0 {
+			continue
+		}
+		head := &flow.infos[0]
+		if oldest == nil || head.time.Before(oldest.time) {
+			oldest = head
+		}
+	}
+	if oldest != nil {
+		return *oldest, true
 	}
 	return
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-// Interface methods for packetQueue to satisfy heap.Interface
-
-func (q *packetQueue) Len() int {
-	return len(q.dests)
-}
-
-func (q *packetQueue) Less(i, j int) bool {
-	return q.dests[i].sources[0].infos[0].time.Before(q.dests[j].sources[0].infos[0].time)
-}
-
-func (q *packetQueue) Swap(i, j int) {
-	q.dests[i], q.dests[j] = q.dests[j], q.dests[i]
-}
-
-func (q *packetQueue) Push(x interface{}) {
-	dest := x.(pqDest)
-	q.dests = append(q.dests, dest)
-	q.size += dest.size
-}
-
-func (q *packetQueue) Pop() interface{} {
-	idx := len(q.dests) - 1
-	dest := q.dests[idx]
-	q.dests = q.dests[:idx]
-	q.size -= dest.size
-	return dest
-}
-
-// Interface methods for pqDest to satisfy heap.Interface
-
-func (d *pqDest) Len() int {
-	return len(d.sources)
-}
-
-func (d *pqDest) Less(i, j int) bool {
-	return d.sources[i].infos[0].time.Before(d.sources[j].infos[0].time)
-}
-
-func (d *pqDest) Swap(i, j int) {
-	d.sources[i], d.sources[j] = d.sources[j], d.sources[i]
-}
-
-func (d *pqDest) Push(x interface{}) {
-	source := x.(pqSource)
-	d.sources = append(d.sources, source)
-	d.size += source.size
-}
-
-func (d *pqDest) Pop() interface{} {
-	idx := len(d.sources) - 1
-	source := d.sources[idx]
-	d.sources = d.sources[:idx]
-	d.size -= source.size
-	return source
 }

--- a/network/peers.go
+++ b/network/peers.go
@@ -72,6 +72,7 @@ func (ps *peers) addPeer(key publicKey, conn net.Conn, prio uint8) (*peer, error
 		p.monitor.pDelay = ps.core.config.peerTimeout // It doesn't make sense to start the ping delay any shorter than this
 		p.writer.peer = p
 		p.writer.wbuf = bufio.NewWriter(p.conn)
+		p.queue.init(ps.core.config.peerMaxMessageSize)
 		p.order = ps.order
 		ps.order++
 		ps.peers[p.key][p] = struct{}{}


### PR DESCRIPTION
This switches the packet queue to a deficit round robin (DRR) design, which promotes better fairness across queues (stops a power imbalance between lots of small packet vs fewer larger packets) and allows us to bound the queue in memory.