### PR TITLE
Implement group password for session auth

### DIFF
--- a/encrypted/crypto.go
+++ b/encrypted/crypto.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/binary"
 
 	"golang.org/x/crypto/nacl/box"
@@ -43,14 +44,22 @@ type edPub [edPubSize]byte
 type edPriv [edPrivSize]byte
 type edSig [edSigSize]byte
 
-func edSign(msg []byte, priv *edPriv) *edSig {
+func edSign(msg []byte, priv *edPriv, preimage []byte) *edSig {
 	var sig edSig
-	copy(sig[:], ed25519.Sign(priv[:], msg))
+	if len(preimage) > 0 {
+		copy(sig[:], ed25519.Sign(priv[:], append(preimage, msg...)))
+	} else {
+		copy(sig[:], ed25519.Sign(priv[:], msg))
+	}
 	return &sig
 }
 
-func edCheck(msg []byte, sig *edSig, pub *edPub) bool {
-	return ed25519.Verify(pub[:], msg, sig[:])
+func edCheck(msg []byte, sig *edSig, pub *edPub, preimage []byte) bool {
+	if len(preimage) > 0 {
+		return ed25519.Verify(pub[:], append(preimage, msg...), sig[:])
+	} else {
+		return ed25519.Verify(pub[:], msg, sig[:])
+	}
 }
 
 func (pub *edPub) asKey() ed25519.PublicKey {
@@ -126,4 +135,30 @@ func nonceForUint64(u64 uint64) boxNonce {
 	slice := nonce[boxNonceSize-8:]
 	binary.BigEndian.PutUint64(slice, u64)
 	return nonce
+}
+
+/*********
+ * group *
+ *********/
+
+type groupAuth struct {
+	enabled bool
+	secret  [32]byte
+}
+
+func newGroupAuth(password string) groupAuth {
+	if password == "" {
+		return groupAuth{}
+	}
+	return groupAuth{
+		enabled: true,
+		secret:  sha256.Sum256(append([]byte("ironwood/encrypted\x00"), []byte(password)...)),
+	}
+}
+
+func (auth groupAuth) preimage() []byte {
+	if auth.enabled {
+		return auth.secret[:]
+	}
+	return nil
 }

--- a/encrypted/crypto_test.go
+++ b/encrypted/crypto_test.go
@@ -24,3 +24,87 @@ func TestEdX25519(t *testing.T) {
 		panic("shared secret mismatch")
 	}
 }
+
+func TestSessionInitPasswordAuth(t *testing.T) {
+	senderPub, senderPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate sender key: %v", err)
+	}
+	receiverPub, receiverPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate receiver key: %v", err)
+	}
+
+	var senderEd edPriv
+	var senderEdPub edPub
+	var receiverEdPriv edPriv
+	var receiverEd edPub
+	copy(senderEd[:], senderPriv)
+	copy(senderEdPub[:], senderPub)
+	copy(receiverEdPriv[:], receiverPriv)
+	copy(receiverEd[:], receiverPub)
+
+	current, _ := newBoxKeys()
+	next, _ := newBoxKeys()
+
+	init := newSessionInit(&current, &next, 9)
+	tests := []struct {
+		name             string
+		senderPassword   string
+		receiverPassword string
+		wantOK           bool
+	}{
+		{
+			name:             "both empty",
+			senderPassword:   "",
+			receiverPassword: "",
+			wantOK:           true,
+		},
+		{
+			name:             "both same password",
+			senderPassword:   "shared-password",
+			receiverPassword: "shared-password",
+			wantOK:           true,
+		},
+		{
+			name:             "sender password only",
+			senderPassword:   "shared-password",
+			receiverPassword: "",
+			wantOK:           false,
+		},
+		{
+			name:             "receiver password only",
+			senderPassword:   "",
+			receiverPassword: "shared-password",
+			wantOK:           false,
+		},
+		{
+			name:             "different passwords",
+			senderPassword:   "shared-password",
+			receiverPassword: "wrong-password",
+			wantOK:           false,
+		},
+	}
+
+	receiverBox := receiverEdPriv.toBox()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := init.encrypt(&senderEd, &receiverEd, newGroupAuth(tc.senderPassword))
+			if err != nil {
+				t.Fatalf("encrypt handshake: %v", err)
+			}
+
+			var decoded sessionInit
+			ok := decoded.decrypt(receiverBox, &senderEdPub, data, newGroupAuth(tc.receiverPassword))
+			if ok != tc.wantOK {
+				t.Fatalf("decrypt = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if decoded.current != init.current || decoded.next != init.next || decoded.keySeq != init.keySeq || decoded.seq != init.seq {
+				t.Fatal("decoded handshake did not round-trip")
+			}
+		})
+	}
+}

--- a/encrypted/packetconn.go
+++ b/encrypted/packetconn.go
@@ -15,6 +15,7 @@ type PacketConn struct {
 	*network.PacketConn
 	secretEd  edPriv
 	secretBox boxPriv
+	groupAuth groupAuth
 	sessions  sessionManager
 	network   netManager
 	Debug     Debug
@@ -22,11 +23,22 @@ type PacketConn struct {
 
 // NewPacketConn returns a *PacketConn struct which implements the types.PacketConn interface.
 func NewPacketConn(secret ed25519.PrivateKey, options ...network.Option) (*PacketConn, error) {
+	return newPacketConn(secret, groupAuth{}, options...)
+}
+
+// NewPacketConnWithPassword returns a *PacketConn that only completes handshakes
+// with peers configured with the same password. The packet format is unchanged;
+// the password is folded into the handshake signature preimage.
+func NewPacketConnWithPassword(secret ed25519.PrivateKey, password string, options ...network.Option) (*PacketConn, error) {
+	return newPacketConn(secret, newGroupAuth(password), options...)
+}
+
+func newPacketConn(secret ed25519.PrivateKey, auth groupAuth, options ...network.Option) (*PacketConn, error) {
 	npc, err := network.NewPacketConn(secret, options...)
 	if err != nil {
 		return nil, err
 	}
-	pc := &PacketConn{PacketConn: npc}
+	pc := &PacketConn{PacketConn: npc, groupAuth: auth}
 	copy(pc.secretEd[:], secret[:])
 	pc.secretBox = *pc.secretEd.toBox()
 	pc.sessions.init(pc)

--- a/encrypted/session.go
+++ b/encrypted/session.go
@@ -84,13 +84,13 @@ func (mgr *sessionManager) handleData(from phony.Actor, pub *edPub, data []byte)
 		case sessionTypeDummy:
 		case sessionTypeInit:
 			init := new(sessionInit)
-			if init.decrypt(&mgr.pc.secretBox, pub, data) {
+			if init.decrypt(&mgr.pc.secretBox, pub, data, mgr.pc.groupAuth) {
 				mgr._handleInit(pub, init)
 			}
 			freeBytes(data)
 		case sessionTypeAck:
 			ack := new(sessionAck)
-			if ack.decrypt(&mgr.pc.secretBox, pub, data) {
+			if ack.decrypt(&mgr.pc.secretBox, pub, data, mgr.pc.groupAuth) {
 				mgr._handleAck(pub, ack)
 			}
 			freeBytes(data)
@@ -178,13 +178,13 @@ func (mgr *sessionManager) _bufferAndInit(toKey edPub, msg []byte) {
 }
 
 func (mgr *sessionManager) sendInit(dest *edPub, init *sessionInit) {
-	if bs, err := init.encrypt(&mgr.pc.secretEd, dest); err == nil {
+	if bs, err := init.encrypt(&mgr.pc.secretEd, dest, mgr.pc.groupAuth); err == nil {
 		mgr.pc.PacketConn.WriteTo(bs, types.Addr(dest.asKey()))
 	}
 }
 
 func (mgr *sessionManager) sendAck(dest *edPub, ack *sessionAck) {
-	if bs, err := ack.encrypt(&mgr.pc.secretEd, dest); err == nil {
+	if bs, err := ack.encrypt(&mgr.pc.secretEd, dest, mgr.pc.groupAuth); err == nil {
 		mgr.pc.PacketConn.WriteTo(bs, types.Addr(dest.asKey()))
 	}
 }
@@ -480,7 +480,7 @@ func newSessionInit(current, next *boxPub, keySeq uint64) sessionInit {
 	return init
 }
 
-func (init *sessionInit) encrypt(from *edPriv, to *edPub) ([]byte, error) {
+func (init *sessionInit) encrypt(from *edPriv, to *edPub, auth groupAuth) ([]byte, error) {
 	fromPub, fromPriv := newBoxKeys()
 	var toBox *boxPub
 	var err error
@@ -499,7 +499,7 @@ func (init *sessionInit) encrypt(from *edPriv, to *edPub) ([]byte, error) {
 	sigBytes = sigBytes[:offset+8]
 	binary.BigEndian.PutUint64(sigBytes[offset:offset+8], init.seq)
 	// Sign
-	sig := edSign(sigBytes, from)
+	sig := edSign(sigBytes, from, auth.preimage())
 	// Prepare the payload (to be encrypted)
 	var payload []byte // TODO initialize to correct size
 	payload = append(payload, sig[:]...)
@@ -519,7 +519,7 @@ func (init *sessionInit) encrypt(from *edPriv, to *edPub) ([]byte, error) {
 	return data, nil
 }
 
-func (init *sessionInit) decrypt(priv *boxPriv, from *edPub, data []byte) bool {
+func (init *sessionInit) decrypt(priv *boxPriv, from *edPub, data []byte, auth groupAuth) bool {
 	if len(data) != sessionInitSize {
 		return false
 	}
@@ -547,7 +547,7 @@ func (init *sessionInit) decrypt(priv *boxPriv, from *edPub, data []byte) bool {
 	var sigBytes []byte
 	sigBytes = append(sigBytes, fromBox[:]...)
 	sigBytes = append(sigBytes, tmp...)
-	return edCheck(sigBytes, &sig, from)
+	return edCheck(sigBytes, &sig, from, auth.preimage())
 }
 
 /**************
@@ -558,8 +558,8 @@ type sessionAck struct {
 	sessionInit
 }
 
-func (ack *sessionAck) encrypt(from *edPriv, to *edPub) ([]byte, error) {
-	data, err := ack.sessionInit.encrypt(from, to)
+func (ack *sessionAck) encrypt(from *edPriv, to *edPub, auth groupAuth) ([]byte, error) {
+	data, err := ack.sessionInit.encrypt(from, to, auth)
 	if err == nil {
 		data[0] = sessionTypeAck
 	}


### PR DESCRIPTION
This makes it possible to have a "closed network" in that you will only be able to establish sessions with other nodes that share the same group password, by preimaging the signature validation with a hash of that password. This is backward compatible with the existing wire protocol as it does not require any changes to the packet format.