### PR TITLE
cap max queue size to max message size

### DIFF
--- a/network/config.go
+++ b/network/config.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const defaultMaxMessageSize = 1048576 // 1 megabyte
+
 type config struct {
 	routerRefresh      time.Duration
 	routerTimeout      time.Duration
@@ -25,7 +27,7 @@ func configDefaults() Option {
 		c.routerTimeout = 5 * time.Minute
 		c.peerKeepAliveDelay = time.Second
 		c.peerTimeout = 3 * time.Second
-		c.peerMaxMessageSize = 1048576 // 1 megabyte
+		c.peerMaxMessageSize = defaultMaxMessageSize
 		c.bloomTransform = func(key ed25519.PublicKey) ed25519.PublicKey { return key }
 		c.pathNotify = func(key ed25519.PublicKey) {}
 		c.pathTimeout = time.Minute

--- a/network/packetconn.go
+++ b/network/packetconn.go
@@ -210,12 +210,17 @@ func (pc *PacketConn) handleTraffic(from phony.Actor, tr *traffic) {
 			case <-pc.closed:
 			}
 		} else {
+			/*
 			if info, ok := pc.recvq.peek(); ok && time.Since(info.time) > 25*time.Millisecond {
 				// The queue already has a significant delay
 				// Drop the oldest packet from the larget queue to make room
 				pc.recvq.drop()
 			}
+			*/
 			pc.recvq.push(tr)
+			for pc.recvq.size > pc.core.config.peerMaxMessageSize {
+				pc.recvq.drop()
+			}
 		}
 	})
 }

--- a/network/packetqueue.go
+++ b/network/packetqueue.go
@@ -59,6 +59,7 @@ func (q *packetQueue) drop() bool {
 	info := source.infos[0]
 	source.size -= info.size
 	if len(source.infos) > 0 {
+		source.infos[0] = pqPacketInfo{}
 		source.infos = source.infos[1:]
 	}
 	dest.sources[sIdx] = source

--- a/network/peers.go
+++ b/network/peers.go
@@ -431,13 +431,19 @@ func (p *peer) _push(packet pqPacket) {
 		return
 	}
 	// We're waiting, so queue the packet up for later
+	/*
 	if info, ok := p.queue.peek(); ok && time.Since(info.time) > 25*time.Millisecond {
 		// The queue already has a significant delay
 		// Drop the oldest packet from the larget queue to make room
 		p.queue.drop()
 	}
+	*/
 	// Add the packet to the queue
 	p.queue.push(packet)
+	// Drop any excess
+	for p.queue.size > p.peers.core.config.peerMaxMessageSize {
+		p.queue.drop()
+	}
 }
 
 func (p *peer) pop() {


### PR DESCRIPTION
Alternative to DRR in #49, this caps max size of any given queue without altering the queue logic. This is a smaller changeset to test things with only the queue size limit.

Compared to DRR, the current queues always send packets in FIFO order (dropping from the largest flow when going over the limit), instead of explicitly sending by round-robin logic. There are probably pros and cons to either approach, it's worth thinking about what makes sense long-term.